### PR TITLE
🗃️ 📝  MySQL 드라이버의 DB명 변경 및 README.md 첫 번째 내용 쓰기

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -1,0 +1,1 @@
+In progress

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 server.port=80
 
 spring.datasource.driverClassName=com.mysql.cj.jdbc.Driver
-spring.datasource.url=jdbc:mysql://101.101.211.229:3306/medicinedb?serverTimezone=Asia/Seoul
+spring.datasource.url=jdbc:mysql://101.101.211.229:3306/emedicine?serverTimezone=Asia/Seoul
 
 spring.datasource.username=admin1
 spring.datasource.password=111111


### PR DESCRIPTION
## 코드 변경 이유
1. `emedicine` DB와 연동하기 위해
2.  GitHub에 `READEME.md`가 표시되는지 확인하기 위해

## 문제
Bug나 문제가 발견되었다면 언급


## 작업사항
1. `application.properties` 파일의 MySQL 드라이버의 DB명을 `medicinedb` -> `emedicine`으로 바꿈
2. `README.md` 파일에 'In progress'라고 씀


## 완료된 테스트
테스트 유무

---
관련 Issue: #5 
